### PR TITLE
WIP: Add ollama support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ An Obsidian plugin that automatically generates daily summaries. It collects not
    - Configure API Endpoint
    - Set report save location
 
+1.1. To use local Ollama models
+   - Set Ollama model you want to use
+      - To find installed models, type `ollama list` into a terminal
+      - Or find interesting local models on https://ollama.com/library
+   - Configure API Endpoint
+      - If you use a different port or run a remote ollama session
+
 2. Generate a report:
    - Use the command palette and search for `Generate Daily Report`
    - The plugin will automatically collect today's notes and generate a summary
@@ -34,6 +41,7 @@ An Obsidian plugin that automatically generates daily summaries. It collects not
 
 - `API Key`: Your LLM API key
 - `API Endpoint`: API endpoint URL
+- `Ollama Model`: Exact name of the Ollama model
 - `Report Location`: Where to save daily reports (e.g., /Daily Reports)
 
 ## Supported Platforms
@@ -58,6 +66,9 @@ The plugin includes comprehensive error logging:
 Luke
 
 ## Changelog
+
+### 1.0.7
+- Ollama support addition
 
 ### 1.0.6
 - Initial release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daily-summary",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Auto generate daily summary",
   "main": "main.js",
   "type": "module",

--- a/setting.ts
+++ b/setting.ts
@@ -1,12 +1,14 @@
 interface PluginSettings {
     apiKey: string;
     apiEndpoint: string;
+    ollamaModel: string;
     reportLocation: string;
 }
 
 const DEFAULT_SETTINGS: PluginSettings = {
     apiKey: '',
     apiEndpoint: '',
+    ollamaModel: '',
     reportLocation: '/'
 };
 


### PR DESCRIPTION
To run ollama models, all that we need is:
- [Ollama server](https://ollama.com/download)
- [Ollama model](https://ollama.com/library)
  - e.g. `ollama pull llama3.1:8b`
- Set the model name in the plugin config
  - e.g. `llama3.1:8b`

If no model is entered, OpenAI API is used instead.

I now recall, that openAI API also allows to choose between different APIs, so this automatic selection has to be replaced with a toggle, or some other, precise, way to distinguish if user wants to use oLLama or openAI 